### PR TITLE
releasenotes: group by major version

### DIFF
--- a/tests/functional/fixtures/EXPECTED_CHANGELOG
+++ b/tests/functional/fixtures/EXPECTED_CHANGELOG
@@ -1,21 +1,65 @@
+* 6.2.3 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR 43b8e854: Mèssage with ûtf-8 ßtuff
+    FIXED ISSUES: https://github.com/david-caro/python-autosemver/issues/42
+
+* 6.2.2 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR 28f5ece1: Mèssage with ûtf-8 ßtuff
+
+* 6.2.1 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR d4316aec: Mèssage with ûtf-8 ßtuff
+
+* 6.2.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    FEATURE 3749523e: Mèssage with ûtf-8 ßtuff
+
+* 6.1.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    FEATURE 0a72639a: Mèssage with ûtf-8 ßtuff
+
+* 6.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MAJOR 49abbd5a: Mèssage with ûtf-8 ßtuff
+
+* 5.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MAJOR 8da2d9ed: Mèssage with ûtf-8 ßtuff
+
+* 4.0.3 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR b587d21c: Mèssage with ûtf-8 ßtuff
+    FIXED ISSUES: https://github.com/david-caro/python-autosemver/issues/42
+
+* 4.0.2 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR 0353fb22: Mèssage with ûtf-8 ßtuff
+
+* 4.0.1 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR c9f8714e: Mèssage with ûtf-8 ßtuff
+
+* 4.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MAJOR d59cffe4: Mèssage with ûtf-8 ßtuff
+
+* 3.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MAJOR a0d17729: Mèssage with ûtf-8 ßtuff
+
+* 2.2.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    FEATURE 8d5e718e: Mèssage with ûtf-8 ßtuff
+
+* 2.1.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    FEATURE 91510a53: Mèssage with ûtf-8 ßtuff
+
 * 2.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MAJOR 921879f3: Mèssage with ûtf-8 ßtuff
+    MAJOR fe7b543b: Mèssage with ûtf-8 ßtuff
 
 * 1.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MAJOR 3e01a9e4: Mèssage with ûtf-8 ßtuff
+    MAJOR d49c576a: Mèssage with ûtf-8 ßtuff
 
 * 0.2.0 "author2 <wöndérfûl@éma.il>"
-    FEATURE d61a3024: Mèssage with ûtf-8 ßtuff
+    FEATURE 46455da1: Mèssage with ûtf-8 ßtuff
 
 * 0.1.0 "author2 <wöndérfûl@éma.il>"
-    FEATURE 39f6a873: Mèssage with ûtf-8 ßtuff
+    FEATURE 225594c5: Mèssage with ûtf-8 ßtuff
 
 * 0.0.3 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MINOR 967bed25: Mèssage with ûtf-8 ßtuff
+    MINOR 6b23fbe6: Mèssage with ûtf-8 ßtuff
     FIXED ISSUES: https://github.com/david-caro/python-autosemver/issues/42
 
 * 0.0.2 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MINOR 229cebfa: Mèssage with ûtf-8 ßtuff
+    MINOR 559d4567: Mèssage with ûtf-8 ßtuff
 
 * 0.0.1 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MINOR c790dd3b: Mèssage with ûtf-8 ßtuff
+    MINOR b4642818: Mèssage with ûtf-8 ßtuff

--- a/tests/functional/fixtures/EXPECTED_RELEASENOTES
+++ b/tests/functional/fixtures/EXPECTED_RELEASENOTES
@@ -1,35 +1,152 @@
+New changes for version 6.2.3
+=================================
 
-New changes for version 2.0.0
+API Breaking changes
+--------------------
+* 6.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MAJOR 5717861b: Mèssage with ûtf-8 ßtuff
+
+New features
+------------
+* 6.2.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    FEATURE 102f8c09: Mèssage with ûtf-8 ßtuff
+
+* 6.1.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    FEATURE b1594a0d: Mèssage with ûtf-8 ßtuff
+
+Bugfixes and minor changes
+--------------------------
+* 6.2.3 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR 67bcba68: Mèssage with ûtf-8 ßtuff
+    FIXED ISSUES: 42
+
+* 6.2.2 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR c8eb802a: Mèssage with ûtf-8 ßtuff
+
+* 6.2.1 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR f1aa044a: Mèssage with ûtf-8 ßtuff
+
+
+New changes for version 5.0.0
+=================================
+
+API Breaking changes
+--------------------
+* 5.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MAJOR fec6e3cf: Mèssage with ûtf-8 ßtuff
+
+New features
+------------
+No new features
+
+Bugfixes and minor changes
+--------------------------
+No new bugs
+
+
+New changes for version 4.0.3
+=================================
+
+API Breaking changes
+--------------------
+* 4.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MAJOR 8ad043f0: Mèssage with ûtf-8 ßtuff
+
+New features
+------------
+No new features
+
+Bugfixes and minor changes
+--------------------------
+* 4.0.3 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR 5bdd63db: Mèssage with ûtf-8 ßtuff
+    FIXED ISSUES: 42
+
+* 4.0.2 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR c3b922aa: Mèssage with ûtf-8 ßtuff
+
+* 4.0.1 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MINOR cbc7bd47: Mèssage with ûtf-8 ßtuff
+
+
+New changes for version 3.0.0
+=================================
+
+API Breaking changes
+--------------------
+* 3.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    MAJOR 29cceb00: Mèssage with ûtf-8 ßtuff
+
+New features
+------------
+No new features
+
+Bugfixes and minor changes
+--------------------------
+No new bugs
+
+
+New changes for version 2.2.0
 =================================
 
 API Breaking changes
 --------------------
 * 2.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MINOR 3f0f3a71: Mèssage with ûtf-8 ßtuff
+    MAJOR 4f411e19: Mèssage with ûtf-8 ßtuff
 
+New features
+------------
+* 2.2.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    FEATURE acd10f08: Mèssage with ûtf-8 ßtuff
+
+* 2.1.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
+    FEATURE 68c3e431: Mèssage with ûtf-8 ßtuff
+
+Bugfixes and minor changes
+--------------------------
+No new bugs
+
+
+New changes for version 1.0.0
+=================================
+
+API Breaking changes
+--------------------
 * 1.0.0 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MINOR 1c416ae0: Mèssage with ûtf-8 ßtuff
+    MAJOR 14aa331f: Mèssage with ûtf-8 ßtuff
 
+New features
+------------
+No new features
+
+Bugfixes and minor changes
+--------------------------
+No new bugs
+
+
+New changes for version 0.2.0
+=================================
+
+API Breaking changes
+--------------------
+No new API breaking changes
 
 New features
 ------------
 * 0.2.0 "author2 <wöndérfûl@éma.il>"
-    MINOR 485189f4: Mèssage with ûtf-8 ßtuff
+    FEATURE a91ccf6f: Mèssage with ûtf-8 ßtuff
 
 * 0.1.0 "author2 <wöndérfûl@éma.il>"
-    MINOR 56e818b9: Mèssage with ûtf-8 ßtuff
-
+    FEATURE 01da9a07: Mèssage with ûtf-8 ßtuff
 
 Bugfixes and minor changes
 --------------------------
 * 0.0.3 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MINOR 7df31cc9: Mèssage with ûtf-8 ßtuff
+    MINOR 2aaa8162: Mèssage with ûtf-8 ßtuff
     FIXED ISSUES: 42
 
 * 0.0.2 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MINOR d7d7bca4: Mèssage with ûtf-8 ßtuff
+    MINOR 0082c1d0: Mèssage with ûtf-8 ßtuff
 
 * 0.0.1 "Wöndérfûl nàmé <wöndérfûl@éma.il>"
-    MINOR c60197b1: Mèssage with ûtf-8 ßtuff
-
-
+    MINOR 7366c308: Mèssage with ûtf-8 ßtuff

--- a/tests/functional/fixtures/EXPECTED_RPM_CHANGELOG
+++ b/tests/functional/fixtures/EXPECTED_RPM_CHANGELOG
@@ -1,22 +1,66 @@
-* Sun Oct 30 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 2.0.0
-    MAJOR 3f0f3a71: Mèssage with ûtf-8 ßtuff
-
-* Sun Oct 30 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 1.0.0
-    MAJOR 1c416ae0: Mèssage with ûtf-8 ßtuff
-
-* Sun Oct 30 2016 author2 <wöndérfûl@éma.il> - 0.2.0
-    FEATURE 485189f4: Mèssage with ûtf-8 ßtuff
-
-* Sun Oct 30 2016 author2 <wöndérfûl@éma.il> - 0.1.0
-    FEATURE 56e818b9: Mèssage with ûtf-8 ßtuff
-
-* Sun Oct 30 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 0.0.3
-    MINOR 7df31cc9: Mèssage with ûtf-8 ßtuff
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 6.2.3
+    MINOR 43b8e854: Mèssage with ûtf-8 ßtuff
     FIXED ISSUES: 42
 
-* Sun Oct 30 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 0.0.2
-    MINOR d7d7bca4: Mèssage with ûtf-8 ßtuff
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 6.2.2
+    MINOR 28f5ece1: Mèssage with ûtf-8 ßtuff
 
-* Sun Oct 30 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 0.0.1
-    MINOR c60197b1: Mèssage with ûtf-8 ßtuff
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 6.2.1
+    MINOR d4316aec: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 6.2.0
+    FEATURE 3749523e: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 6.1.0
+    FEATURE 0a72639a: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 6.0.0
+    MAJOR 49abbd5a: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 5.0.0
+    MAJOR 8da2d9ed: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 4.0.3
+    MINOR b587d21c: Mèssage with ûtf-8 ßtuff
+    FIXED ISSUES: 42
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 4.0.2
+    MINOR 0353fb22: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 4.0.1
+    MINOR c9f8714e: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 4.0.0
+    MAJOR d59cffe4: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 3.0.0
+    MAJOR a0d17729: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 2.2.0
+    FEATURE 8d5e718e: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 2.1.0
+    FEATURE 91510a53: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 2.0.0
+    MAJOR fe7b543b: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 1.0.0
+    MAJOR d49c576a: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 author2 <wöndérfûl@éma.il> - 0.2.0
+    FEATURE 46455da1: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 author2 <wöndérfûl@éma.il> - 0.1.0
+    FEATURE 225594c5: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 0.0.3
+    MINOR 6b23fbe6: Mèssage with ûtf-8 ßtuff
+    FIXED ISSUES: 42
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 0.0.2
+    MINOR 559d4567: Mèssage with ûtf-8 ßtuff
+
+* Sat Nov 26 2016 Wöndérfûl nàmé <wöndérfûl@éma.il> - 0.0.1
+    MINOR b4642818: Mèssage with ûtf-8 ßtuff
 


### PR DESCRIPTION
* Nicer release notes, now grouping them by major version to give a
  better view of what each version introduced and a better timeline
  order.
* Improved a bit the tests to have more commits.

Signed-off-by: David Caro <david@dcaro.es>