### PR TITLE
Fix non-newline terminated commit issue

### DIFF
--- a/autosemver/git.py
+++ b/autosemver/git.py
@@ -50,7 +50,7 @@ FEAT_HEADER = re.compile(
     flags=re.IGNORECASE,
 )
 FEAT_MSG = re.compile(r'\n\* NEW')
-MAJOR_HEADER = re.compile(r'\nsem-ver:\s*.*break.*\n', flags=re.IGNORECASE)
+MAJOR_HEADER = re.compile(r'\nsem-ver:\s*.*break.*(\n|$)', flags=re.IGNORECASE)
 MAJOR_MSG = re.compile(r'\n\* INCOMPATIBLE')
 
 

--- a/autosemver/git.py
+++ b/autosemver/git.py
@@ -404,7 +404,7 @@ def get_version(commit, tags, maj_version=0, feat_version=0, fix_version=0,
 
 
 def is_api_break(commit):
-    return (
+    return bool(
         MAJOR_HEADER.search(_to_str(commit.message)) or
         MAJOR_MSG.search(_to_str(commit.message))
     )

--- a/autosemver/git.py
+++ b/autosemver/git.py
@@ -46,7 +46,7 @@ BUG_URL_REG = re.compile(
 )
 VALID_TAG = re.compile(r'^v?\d+\.\d+(\.\d+)?$')
 FEAT_HEADER = re.compile(
-    r'\nsem-ver:\s*.*(feature|deprecat).*\n',
+    r'\nsem-ver:\s*.*(feature|deprecat).*(\n|$)',
     flags=re.IGNORECASE,
 )
 FEAT_MSG = re.compile(r'\n\* NEW')

--- a/autosemver/git.py
+++ b/autosemver/git.py
@@ -411,7 +411,7 @@ def is_api_break(commit):
 
 
 def is_feature(commit):
-    return (
+    return bool(
         FEAT_HEADER.search(_to_str(commit.message)) or
         FEAT_MSG.search(_to_str(commit.message))
     )

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -19,6 +19,7 @@
 # MA 02111-1307, USA.
 from __future__ import absolute_import, division, print_function
 
+import mock
 import pytest
 import six
 
@@ -145,3 +146,49 @@ def test_fit_to_cols(cols, expected, indent, text):
     result = git.fit_to_cols(**params)
 
     assert result == expected
+
+
+@parametrize({
+    'sem-ver header with newline is feature': {
+        'commit_msg': 'Subject\n\nsem-ver: feature\n',
+        'expected': True,
+    },
+    'sem-ver header without newline is feature': {
+        'commit_msg': 'Subject\n\nsem-ver: feature',
+        'expected': True,
+    },
+    'random caps sem-ver header is feature': {
+        'commit_msg': 'Subject\n\nsEm-VeR: FeAtUre\n',
+        'expected': True,
+    },
+    'sem-ver header with deprecated is feature': {
+        'commit_msg': 'Subject\n\nsem-ver: deprecated\n',
+        'expected': True,
+    },
+    'random caps sem-ver header with deprecated is feature': {
+        'commit_msg': 'Subject\n\nsem-ver: DePrecated\n',
+        'expected': True,
+    },
+    'message with NEW is feature': {
+        'commit_msg': 'Subject\n\n* NEW: fancy stuff\n',
+        'expected': True,
+    },
+    'message wthout header or NEW is NOT feature': {
+        'commit_msg': 'Subject\n\nSome random feature text.\n',
+        'expected': False,
+    },
+    'empty message is NOT feature': {
+        'commit_msg': '',
+        'expected': False,
+    },
+    'message with sem-ver in subject is NOT feature': {
+        'commit_msg': 'sem-ver: feature\n',
+        'expected': False,
+    },
+})
+def test_is_feature(commit_msg, expected):
+
+    commit = mock.MagicMock()
+    commit.message = commit_msg
+
+    assert git.is_feature(commit) == expected

--- a/tests/unit/test_git.py
+++ b/tests/unit/test_git.py
@@ -192,3 +192,45 @@ def test_is_feature(commit_msg, expected):
     commit.message = commit_msg
 
     assert git.is_feature(commit) == expected
+
+
+@parametrize({
+    'sem-ver header with newline is major': {
+        'commit_msg': 'Subject\n\nsem-ver: api-breaking\n',
+        'expected': True,
+    },
+    'sem-ver header without newline is major': {
+        'commit_msg': 'Subject\n\nsem-ver: api-breaking',
+        'expected': True,
+    },
+    'sem-ver header with \'break\' is major': {
+        'commit_msg': 'Subject\n\nsem-ver: breaks compatibility',
+        'expected': True,
+    },
+    'random caps sem-ver header is major': {
+        'commit_msg': 'Subject\n\nsEm-VeR: ApI-BrEaKinG\n',
+        'expected': True,
+    },
+    'message with INCOMPATIBLE is major': {
+        'commit_msg': 'Subject\n\n* INCOMPATIBLE: old stuff\n',
+        'expected': True,
+    },
+    'message wthout header or INCOMPATIBLE is NOT major': {
+        'commit_msg': 'Subject\n\nSome random thing text.\n',
+        'expected': False,
+    },
+    'empty message is NOT major': {
+        'commit_msg': '',
+        'expected': False,
+    },
+    'message with sem-ver in subject is NOT major': {
+        'commit_msg': 'sem-ver: breaking change\n',
+        'expected': False,
+    },
+})
+def test_is_api_break(commit_msg, expected):
+
+    commit = mock.MagicMock()
+    commit.message = commit_msg
+
+    assert git.is_api_break(commit) == expected


### PR DESCRIPTION
* It was not being detected as feature/major change if the sem-ver
  header did not end with a newline (only seems to happen with
  github merge commit messages).